### PR TITLE
loading metadata from sidecar file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 tokio-rustls = "0.22.0"
-tokio = { version = "1.0", features = ["fs", "io-util", "net", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["fs", "io-util", "net", "rt-multi-thread", "sync"] }
 env_logger = { version = "0.8", default-features = false, features = ["atty", "humantime", "termcolor"] }
 getopts = "0.2.21"
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -50,9 +50,8 @@ The lines of the file should have this format:
 <filename>:<metadata>
 ```
 
-Where `<filename>` is just a filename (not a path) of a file in the same directory, and `<metadata>` is the metadata to be stored.
-Lines that start with optional whitespace and `#` are ignored, as are lines that do not fit the above basic format.
-Both parts are stripped of any leading and/or trailing whitespace.
+Where `<filename>` is just a filename (not a path) of a file in the same directory, and `<metadata>` is the MIME type to be stored. If `<metadata>` starts with a semicolon, agate will use the usual mechanism to determine the mime type of the file and append the specified parameters.
+Lines that start with optional whitespace and `#` are ignored, as are lines that do not contain a `:`. Both parts are stripped of any leading and/or trailing whitespace.
 
 [Gemini]: https://gemini.circumlunar.space/
 [Rust]: https://www.rust-lang.org/

--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ All of the command-line arguments are optional.  Run `agate --help` to see the d
 
 When a client requests the URL `gemini://example.com/foo/bar`, Agate will respond with the file at `path/to/content/foo/bar`. If any segment of the requested path starts with a dot, agate will respond with a status code 52, even if the file does not exist (this behaviour can be disabled with `--serve-secret`). If there is a directory at that path, Agate will look for a file named `index.gmi` inside that directory. If there is no such file, but a file named `.directory-listing-ok` exists inside that directory, a basic directory listing is displayed. Files or directories whose name starts with a dot (e.g. the `.directory-listing-ok` file itself) are omitted from the list.
 
+Agate will look for a file called `.lang` in the same directory as the file currently being served. If this file exists and has an entry for the current file, the respective data will be used to formulate the response header.
+The lines of the file should have this format:
+
+```text
+<filename>:<metadata>
+```
+
+Where `<filename>` is just a filename (not a path) of a file in the same directory, and `<metadata>` is the metadata to be stored.
+Lines that start with optional whitespace and `#` are ignored, as are lines that do not fit the above basic format.
+Both parts are stripped of any leading and/or trailing whitespace.
+
 [Gemini]: https://gemini.circumlunar.space/
 [Rust]: https://www.rust-lang.org/
 [home]: gemini://gem.limpet.net/agate/

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ All of the command-line arguments are optional.  Run `agate --help` to see the d
 
 When a client requests the URL `gemini://example.com/foo/bar`, Agate will respond with the file at `path/to/content/foo/bar`. If any segment of the requested path starts with a dot, agate will respond with a status code 52, even if the file does not exist (this behaviour can be disabled with `--serve-secret`). If there is a directory at that path, Agate will look for a file named `index.gmi` inside that directory. If there is no such file, but a file named `.directory-listing-ok` exists inside that directory, a basic directory listing is displayed. Files or directories whose name starts with a dot (e.g. the `.directory-listing-ok` file itself) are omitted from the list.
 
-Agate will look for a file called `.lang` in the same directory as the file currently being served. If this file exists and has an entry for the current file, the respective data will be used to formulate the response header.
+Agate will look for a file called `.mime` in the same directory as the file currently being served. If this file exists and has an entry for the current file, the respective data will be used to formulate the response header.
 The lines of the file should have this format:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ You can put a file called `.meta` in a directory that stores some metadata about
 Lines starting with a `#` are comments and will be ignored like empty lines. All other lines must start with a file name (not a path), followed by a colon and then the metadata.
 
 The metadata can take one of four possible forms:
-1. empty
+1. empty  
     Agate will not send a default language parameter, even if it was specified on the command line.
-2. starting with a semicolon followed by MIME parameters
+2. starting with a semicolon followed by MIME parameters  
     Agate will append the specified string onto the MIME type, if the file is found.
-3. starting with a gemini status code (i.e. a digit 1-6 inclusive followed by another digit) and a space
+3. starting with a gemini status code (i.e. a digit 1-6 inclusive followed by another digit) and a space  
     Agate will send the metadata wether the file exists or not. The file will not be sent or accessed.
-4. a MIME type, may include parameters
+4. a MIME type, may include parameters  
     Agate will use this MIME type instead of what it would guess, if the file is found.
     The default language parameter will not be used, even if it was specified on the command line.
 

--- a/README.md
+++ b/README.md
@@ -41,17 +41,42 @@ agate --content path/to/content/ \
 
 All of the command-line arguments are optional.  Run `agate --help` to see the default values used when arguments are omitted.
 
-When a client requests the URL `gemini://example.com/foo/bar`, Agate will respond with the file at `path/to/content/foo/bar`. If any segment of the requested path starts with a dot, agate will respond with a status code 52, even if the file does not exist (this behaviour can be disabled with `--serve-secret`). If there is a directory at that path, Agate will look for a file named `index.gmi` inside that directory. If there is no such file, but a file named `.directory-listing-ok` exists inside that directory, a basic directory listing is displayed. Files or directories whose name starts with a dot (e.g. the `.directory-listing-ok` file itself) are omitted from the list.
+When a client requests the URL `gemini://example.com/foo/bar`, Agate will respond with the file at `path/to/content/foo/bar`. If any segment of the requested path starts with a dot, agate will respond with a status code 52, wether the file exists or not (this behaviour can be disabled with `--serve-secret`). If there is a directory at that path, Agate will look for a file named `index.gmi` inside that directory.
 
-Agate will look for a file called `.mime` in the same directory as the file currently being served. If this file exists and has an entry for the current file, the respective data will be used to formulate the response header.
-The lines of the file should have this format:
+## Configuration
 
+### Directory listing
+
+You can enable a basic directory listing for a directory by putting a file called `.directory-listing-ok` in that directory. This does not have an effect on subdirectories.
+The directory listing will hide files and directories whose name starts with a dot (e.g. the `.directory-listing-ok` file itself or also the `.meta` configuration file).
+
+A file called `index.gmi` will always take precedence over a directory listing.
+
+### Meta-Presets
+
+You can put a file called `.meta` in a directory that stores some metadata about these files which Agate will use when serving these files. The file should be UTF-8 encoded. Like the `.directory-listing-ok` file, this file does not have an effect on subdirectories.
+Lines starting with a `#` are comments and will be ignored like empty lines. All other lines must start with a file name (not a path), followed by a colon and then the metadata.
+
+The metadata can take one of four possible forms:
+1. empty
+    Agate will not send a default language parameter, even if it was specified on the command line.
+2. starting with a semicolon followed by MIME parameters
+    Agate will append the specified string onto the MIME type, if the file is found.
+3. starting with a gemini status code (i.e. a digit 1-6 inclusive followed by another digit) and a space
+    Agate will send the metadata wether the file exists or not. The file will not be sent or accessed.
+4. a MIME type, may include parameters
+    Agate will use this MIME type instead of what it would guess, if the file is found.
+    The default language parameter will not be used, even if it was specified on the command line.
+
+If a line violates the format or looks like case 3, but is incorrect, it might be ignored. You should check your logs. Please know that this configuration file is first read when a file from the respective directory is accessed. So no log messages after startup does not mean the `.meta` file is okay.
+
+Such a configuration file might look like this:
 ```text
-<filename>:<metadata>
+# This line will be ignored.
+index.gmi:;lang=en-UK
+LICENSE:text/plain;charset=UTF-8
+gone.gmi:52 This file is no longer here, sorry.
 ```
-
-Where `<filename>` is just a filename (not a path) of a file in the same directory, and `<metadata>` is the MIME type to be stored. If `<metadata>` starts with a semicolon, agate will use the usual mechanism to determine the mime type of the file and append the specified parameters.
-Lines that start with optional whitespace and `#` are ignored, as are lines that do not contain a `:`. Both parts are stripped of any leading and/or trailing whitespace.
 
 [Gemini]: https://gemini.circumlunar.space/
 [Rust]: https://www.rust-lang.org/

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod metadata;
+
 use {
     once_cell::sync::Lazy,
     percent_encoding::{percent_decode_str, percent_encode, AsciiSet, CONTROLS},

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,15 +9,8 @@ use {
         NoClientAuth, ServerConfig,
     },
     std::{
-        borrow::Cow,
-        error::Error,
-        ffi::OsStr,
-        fmt::Write,
-        fs::File,
-        io::BufReader,
-        net::SocketAddr,
-        path::Path,
-        sync::Arc,
+        borrow::Cow, error::Error, ffi::OsStr, fmt::Write, fs::File, io::BufReader,
+        net::SocketAddr, path::Path, sync::Arc,
     },
     tokio::{
         io::{AsyncReadExt, AsyncWriteExt},
@@ -122,7 +115,11 @@ fn args() -> Result<Args> {
     );
     opts.optflag("s", "silent", "Disable logging output");
     opts.optflag("h", "help", "Print this help menu");
-    opts.optflag("", "serve-secret", "Enable serving secret files (files/directories starting with a dot)");
+    opts.optflag(
+        "",
+        "serve-secret",
+        "Enable serving secret files (files/directories starting with a dot)",
+    );
     opts.optflag("", "log-ip", "Output IP addresses when logging");
 
     let matches = opts.parse(&args[1..]).map_err(|f| f.to_string())?;
@@ -153,7 +150,7 @@ fn args() -> Result<Args> {
         language: matches.opt_str("lang"),
         silent: matches.opt_present("s"),
         serve_secret: matches.opt_present("serve-secret"),
-    	log_ips: matches.opt_present("log-ip"),
+        log_ips: matches.opt_present("log-ip"),
     })
 }
 
@@ -205,7 +202,11 @@ impl RequestHandle {
         );
 
         match TLS.accept(stream).await {
-            Ok(stream) => Ok(Self { stream, log_line, metadata }),
+            Ok(stream) => Ok(Self {
+                stream,
+                log_line,
+                metadata,
+            }),
             Err(e) => Err(format!("{} error:{}", log_line, e)),
         }
     }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -8,7 +8,7 @@ use std::time::SystemTime;
 ///
 /// These sidecar file's lines should have the format
 /// ```text
-/// <filename>:<metadata>\n
+/// <filename>:<metadata>
 /// ```
 /// where `<filename>` is only a filename (not a path) of a file that resides
 /// in the same directory and `<metadata>` is the metadata to be stored.

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,0 +1,114 @@
+use std::collections::BTreeMap;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+/// A struct to store a string of metadata for each file retrieved from
+/// sidecar files called `.lang`.
+///
+/// These sidecar file's lines should have the format
+/// ```text
+/// <filename>:<metadata>\n
+/// ```
+/// where `<filename>` is only a filename (not a path) of a file that resides
+/// in the same directory and `<metadata>` is the metadata to be stored.
+/// Lines that start with optional whitespace and `#` are ignored, as are lines
+/// that do not fit the basic format.
+/// Both parts are stripped of any leading and/or trailing whitespace.
+pub(crate) struct FileOptions {
+    /// Stores the paths of the side files and when they were last read.
+    /// By comparing this to the last write time, we can know if the file
+    /// has changed.
+    databases_read: BTreeMap<PathBuf, SystemTime>,
+    /// Stores the metadata for each file
+    file_meta: BTreeMap<PathBuf, String>,
+    /// The default value to return
+    default: String,
+}
+
+impl FileOptions {
+    pub(crate) fn new(default: &String) -> Self {
+        Self {
+            databases_read: BTreeMap::new(),
+            file_meta: BTreeMap::new(),
+            default: default.clone(),
+        }
+    }
+
+    /// Checks wether the database for the respective directory is still
+    /// up to date.
+    /// Will only return true if the database should be (re)read, i.e. it will
+    /// return false if there is no database file in the specified directory.
+    fn check_outdated(&self, db_dir: &PathBuf) -> bool {
+        let mut db = db_dir.clone();
+        db.push(".lang");
+        let db = db.as_path();
+
+        if let Ok(metadata) = db.metadata() {
+            if !metadata.is_file() {
+                // it exists, but it is a directory
+                false
+            } else if let (Ok(modified), Some(last_read)) =
+                (metadata.modified(), self.databases_read.get(db))
+            {
+                // check that it was last modified before the read
+                // if the times are the same, we might have read the old file
+                &modified < last_read
+            } else {
+                // either the filesystem does not support last modified
+                // metadata, so we have to read it again every time; or the
+                // file exists but was not read before, so we have to read it
+                true
+            }
+        } else {
+            // the file probably does not exist
+            false
+        }
+    }
+
+    /// (Re)reads a specific sidecar file that resides in the specified
+    /// directory. The function takes a directory to minimize path
+    /// alterations "on the fly".
+    /// This function will allways try to read the file, even if it is current.
+    fn read_database(&mut self, db_dir: &PathBuf) {
+        let mut db = db_dir.clone();
+        db.push(".lang");
+        let db = db.as_path();
+
+        if let Ok(file) = std::fs::File::open(db) {
+            let r = BufReader::new(file);
+            r.lines()
+                // discard any I/O errors
+                .filter_map(|line| line.ok())
+                // filter out comment lines
+                .filter(|line| !line.trim_start().starts_with("#"))
+                .for_each(|line| {
+                    // split line at colon
+                    let parts = line.splitn(2, ':').collect::<Vec<_>>();
+                    // only continue if line fits the format
+                    if parts.len() == 2 {
+                        // generate workspace-unique path
+                        let mut path = db_dir.clone();
+                        path.push(parts[0].trim());
+                        self.file_meta.insert(path, parts[1].trim().to_string());
+                    }
+                });
+            self.databases_read
+                .insert(db_dir.clone(), SystemTime::now());
+        }
+    }
+
+    /// Get the metadata for the specified file. This might need to (re)load a
+    /// single sidecar file.
+    /// The file path should consistenly be either absolute or relative to the
+    /// working/content directory. If inconsisten file paths are used, this can
+    /// lead to loading and storing sidecar files multiple times.
+    pub fn get(&mut self, file: PathBuf) -> &str {
+        let dir = file.parent().expect("no parent directory").to_path_buf();
+        if self.check_outdated(&dir) {
+            self.read_database(&dir);
+        }
+
+        self.file_meta.get(&file).unwrap_or(&self.default)
+    }
+}


### PR DESCRIPTION
This could resolve #6.
I am not sure how this should be tied into sending replies, since this would more or less be global state.
I am also not sure what should be put in the sidecar files. In theory these could contain the whole `<META>` part of the response, but it is probably undesirable to verbosely specify `text/gemini;lang=` for most cases. On the other hand this might be a nice feature for some other files. Or there could be two different formats where one lets the server decide the MIME type.

And this is once again synchronous code. I don't really see how this would be improved by making it async, but if preferred, I could try to rewrite it. Or maybe this should run in a separate thread using something like [notify](https://crates.io/crates/notify) to update the databases in the background.

I don't really know how to continue from here so any feedback would be greatly appreciated.