### PR TITLE
do not serve hidden files

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ agate --content path/to/content/ \
 
 All of the command-line arguments are optional.  Run `agate --help` to see the default values used when arguments are omitted.
 
-When a client requests the URL `gemini://example.com/foo/bar`, Agate will respond with the file at `path/to/content/foo/bar`.  If there is a directory at that path, Agate will look for a file named `index.gmi` inside that directory. If there is no such file, but a file named `.directory-listing-ok` exists inside that directory, a basic directory listing is displayed. Files whose name starts with a dot (e.g. `.hidden`) are omitted from the list.
+When a client requests the URL `gemini://example.com/foo/bar`, Agate will respond with the file at `path/to/content/foo/bar`. If the requested file or directory name starts with a dot, agate will respond with a status code 52, even if the file does not exist. If there is a directory at that path, Agate will look for a file named `index.gmi` inside that directory. If there is no such file, but a file named `.directory-listing-ok` exists inside that directory, a basic directory listing is displayed. Files whose name starts with a dot (e.g. `.hidden`) are omitted from the list.
 
 [Gemini]: https://gemini.circumlunar.space/
 [Rust]: https://www.rust-lang.org/

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,9 +183,12 @@ async fn send_response(url: Url, stream: &mut TlsStream<TcpStream>) -> Result {
     }
 
     // Do not serve anything that looks like a hidden file.
-    if !ARGS.serve_secret && path.file_name().map_or(false, |name| {
-        name.to_str().map_or(false, |name| name.starts_with("."))
-    }) {
+    if !ARGS.serve_secret
+        && path
+            .iter()
+            .filter_map(|component| component.to_str())
+            .any(|component| component.starts_with("."))
+    {
         return send_header(stream, 52, &["If I told you, it would not be a secret."]).await;
     }
 


### PR DESCRIPTION
Do not serve anything that looks like a secret file (file/directory name starts with a dot). There is the new flag `--serve-secret` to reenable the old behaviour.