### PR TITLE
correctly redirect directories

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,9 @@ async fn send_response(url: Url, stream: &mut TlsStream<TcpStream>) -> Result {
                 }
             } else {
                 // if client is not redirected, links may not work as expected without trailing slash
-                return send_header(stream, 31, &[url.as_str(), "/"]).await;
+                let mut url = url;
+                url.set_path(&format!("{}/", url.path()));
+                return send_header(stream, 31, &[url.as_str()]).await;
             }
         }
     }


### PR DESCRIPTION
This fixes the issue brought up on the mailing list: <https://lists.orbitalfox.eu/archives/gemini/2021/004827.html> Although agate does not support CGI, that would not stop clients from requesting paths with a query part which would also result in the same infinte redirection and quite large log files. Instead of appending the slash to the end of the full URL, append it to the end of the path.