### PR TITLE
check port against TCP stream's port

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,15 @@ openssl req -x509 -newkey rsa:4096 -keyout key.rsa -out cert.pem \
 agate --content path/to/content/ \
       --key key.rsa \
       --cert cert.pem \
-      --addr :: \
-      --addr 0.0.0.0 \
-      --port 1965 \
+      --addr :::1965 \
+      --addr 0.0.0.0:1965 \
       --hostname example.com \
       --lang en-US
 ```
 
 All of the command-line arguments are optional.  Run `agate --help` to see the default values used when arguments are omitted.
 
-When a client requests the URL `gemini://example.com/foo/bar`, Agate will respond with the file at `path/to/content/foo/bar`. If the requested file or directory name starts with a dot, agate will respond with a status code 52, even if the file does not exist. If there is a directory at that path, Agate will look for a file named `index.gmi` inside that directory. If there is no such file, but a file named `.directory-listing-ok` exists inside that directory, a basic directory listing is displayed. Files whose name starts with a dot (e.g. `.hidden`) are omitted from the list.
+When a client requests the URL `gemini://example.com/foo/bar`, Agate will respond with the file at `path/to/content/foo/bar`. If any segment of the requested path starts with a dot, agate will respond with a status code 52, even if the file does not exist (this behaviour can be disabled with `--serve-secret`). If there is a directory at that path, Agate will look for a file named `index.gmi` inside that directory. If there is no such file, but a file named `.directory-listing-ok` exists inside that directory, a basic directory listing is displayed. Files or directories whose name starts with a dot (e.g. the `.directory-listing-ok` file itself) are omitted from the list.
 
 [Gemini]: https://gemini.circumlunar.space/
 [Rust]: https://www.rust-lang.org/

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ fn args() -> Result<Args> {
     opts.optopt("", "content", "Root of the content directory (default ./content)", "DIR");
     opts.optopt("", "cert", "TLS certificate PEM file (default ./cert.pem)", "FILE");
     opts.optopt("", "key", "PKCS8 private key file (default ./key.rsa)", "FILE");
-    opts.optmulti("", "addr", "Address to listen on (multiple occurences possible, default 0.0.0.0:1965 and [::]:1965)", "IP");
+    opts.optmulti("", "addr", "Address to listen on (multiple occurences possible, default 0.0.0.0:1965 and [::]:1965)", "IP:PORT");
     opts.optopt("", "hostname", "Domain name of this Gemini server (optional)", "NAME");
     opts.optopt("", "lang", "RFC 4646 Language code(s) for text/gemini documents", "LANG");
     opts.optflag("s", "silent", "Disable logging output");


### PR DESCRIPTION
The port is checked against the socket address the TCP stream is locally connected to. This allows to specify the port for each address individually and remove the separate `--port` switch (thus undoing the breaking CLI argument change, in itself a breaking change).