### PR TITLE
fix flag name use

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ fn args() -> Result<Args> {
         language: matches.opt_str("lang"),
         silent: matches.opt_present("s"),
         serve_secret: matches.opt_present("serve-secret"),
-        log_ips: matches.opt_present("ip"),
+        log_ips: matches.opt_present("log-ip"),
     })
 }
 


### PR DESCRIPTION
I did not update the second place the flag name is used in commit 116c9fdcb43758b591394c06a66da7d61e08481e. This way the program always panics when run.