### PR TITLE
help exit with code 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Have help exit with successfully with `0` rather than `1`
+
 ## [2.5.2] - 2021-02-12
 
 ### Fixed

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,8 +146,8 @@ fn args() -> Result<Args> {
 
     let matches = opts.parse(&args[1..]).map_err(|f| f.to_string())?;
     if matches.opt_present("h") {
-        let usage = opts.usage(&format!("Usage: {} [options]", &args[0]));
-        return Err(usage.into());
+        eprintln!("{}", opts.usage(&format!("Usage: {} [options]", &args[0])));
+        std::process::exit(0);
     }
     let mut hostnames = vec![];
     for s in matches.opt_strs("hostname") {


### PR DESCRIPTION
It's pretty annoying that `--help` exits with code `1` as it's not the program failing, it's successfully logging out the help message.

This PR makes it exit with code `0`

