### PR TITLE
corrected certficate path for docker container in docker readme

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -45,7 +45,7 @@ This process will take a few minutes because all the rust modules have to be com
 ## start the docker container
 
 ```
-docker run -t -d --name agate -p 1965:1965 -d /var/www/gmi/:/gmi/ -d /var/www/gmi/.certificates/:/agate/.certificates/ -e GEMINI_HOST=my.gemini.space -e GEMINI_LANG=en-US agate:latest
+docker run -t -d --name agate -p 1965:1965 -d /var/www/gmi/:/gmi/ -d /var/www/gmi/.certificates/:/.certificates/ -e GEMINI_HOST=my.gemini.space -e GEMINI_LANG=en-US agate:latest
 ```
 
 You have to replace `/var/www/gmi/` with the folder where you'd like to have gemtext files and `/var/www/gmi/.certificates/` with the folder where you'd like to have your certificates stored. You also have to have to replace `my.gemini.space` with your domain name and if plan to speak in a different language than english in your gemini space than you should replace `en-US` with your countries language code (for example de-DE or fr-CA).

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -45,9 +45,9 @@ This process will take a few minutes because all the rust modules have to be com
 ## start the docker container
 
 ```
-docker run -t -d --name agate -p 1965:1965 -d /var/www/gmi/:/gmi/ -d /var/www/gmi/.certificates/:/.certificates/ -e GEMINI_HOST=my.gemini.space -e GEMINI_LANG=en-US agate:latest
+docker run -t -d --name agate -p 1965:1965 -d /var/www/gmi/:/gmi/ -d /var/www/gmi/.certificates/:/.certificates/ -e GEMINI_HOST=example.org -e GEMINI_LANG=en-US agate:latest
 ```
 
-You have to replace `/var/www/gmi/` with the folder where you'd like to have gemtext files and `/var/www/gmi/.certificates/` with the folder where you'd like to have your certificates stored. You also have to have to replace `my.gemini.space` with your domain name and if plan to speak in a different language than english in your gemini space than you should replace `en-US` with your countries language code (for example de-DE or fr-CA).
+You have to replace `/var/www/gmi/` with the folder where you'd like to have gemtext files and `/var/www/gmi/.certificates/` with the folder where you'd like to have your certificates stored. You also have to have to replace `example.org` with your domain name and if plan to speak in a different language than english in your gemini space than you should replace `en-US` with your countries language code (for example de-DE or fr-CA).
 
 ## That's it! Now have agate running in a docker container!


### PR DESCRIPTION
Hi, it's me again😅
In tools/docker/README.md was the wrong path for the certificates inside specified.