### PR TITLE
updating docker tools

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,5 +1,12 @@
 FROM alpine:latest
 RUN apk add cargo && wget https://github.com/mbrubeck/agate/archive/refs/tags/v3.0.2.tar.gz && tar xzf v3.0.2.tar.gz && mv /agate-3.0.2 /agate && cd agate && cargo build --release
-CMD /agate --content /gmi/ \
-	--hostname $GEMINI_HOST \
-	--lang $GEMINI_LANG
+# ENTRYPOINT ["/agate", "--content /gmi/", "--hostname localhost", "--lang en-US"]
+RUN cp /agate/target/release/agate /usr/bin/agate
+WORKDIR /app
+COPY . /app
+ADD . .
+ENTRYPOINT ["/bin/sh", "start.sh"]
+#ENTRYPOINT ["agate --content /gmi/"]
+#CMD ["--hostname localhost", "--lang en-US"]
+#CMD agate --content /gmi --hostname localhost
+

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,12 +1,8 @@
 FROM alpine:latest
 RUN apk add cargo && wget https://github.com/mbrubeck/agate/archive/refs/tags/v3.0.2.tar.gz && tar xzf v3.0.2.tar.gz && mv /agate-3.0.2 /agate && cd agate && cargo build --release
-# ENTRYPOINT ["/agate", "--content /gmi/", "--hostname localhost", "--lang en-US"]
 RUN cp /agate/target/release/agate /usr/bin/agate
 WORKDIR /app
 COPY . /app
 ADD . .
 ENTRYPOINT ["/bin/sh", "start.sh"]
-#ENTRYPOINT ["agate --content /gmi/"]
-#CMD ["--hostname localhost", "--lang en-US"]
-#CMD agate --content /gmi --hostname localhost
 

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -45,7 +45,7 @@ This process will take a few minutes because all the rust modules have to be com
 ## start the docker container
 
 ```
-docker run -t -d --name agate -p 1965:1965 -d /var/www/gmi/:/gmi/ -d /var/www/gmi/.certificates/:/.certificates/ -e GEMINI_HOST=example.org -e GEMINI_LANG=en-US agate:latest
+docker run -t -d -p 1965:1965 -v /var/www/gmi/:/gmi/ -v /var/www/gmi/.certificates/:/.certificates/ -e HOSTNAME=example.org -e LANG=en-US agate:latest
 ```
 
 You have to replace `/var/www/gmi/` with the folder where you'd like to have gemtext files and `/var/www/gmi/.certificates/` with the folder where you'd like to have your certificates stored. You also have to have to replace `example.org` with your domain name and if plan to speak in a different language than english in your gemini space than you should replace `en-US` with your countries language code (for example de-DE or fr-CA).

--- a/tools/docker/start.sh
+++ b/tools/docker/start.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+exec agate --content /gmi/ \
+	--hostname ${HOSTNAME} \
+	--lang ${LANG}
+


### PR DESCRIPTION
Hi,

The exisiting docker instructions and files didn't work for me.
 
The docker run line had used -d for the volumes, which I think should be -v.

The location of the agate bin after building it with cargo wasn't where the Dockerfile said it was (it was  /agate/target/release/agate, not /agate), so the docker wouldn't launch. I copied the agate file to /usr/bin/agate. Then the CMD line wasn't working, so I moved the agate command line to start.sh and called it with ENTRYPOINT. After this, it works for me. 

I hope this helps? 