### PR TITLE
Updated docker run instructions

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -45,7 +45,7 @@ This process will take a few minutes because all the rust modules have to be com
 ## start the docker container
 
 ```
-docker run -t -d -p 1965:1965 -v /var/www/gmi/:/gmi/ -v /var/www/gmi/.certificates/:/.certificates/ -e HOSTNAME=example.org -e LANG=en-US agate:latest
+docker run -t -d --name agate -p 1965:1965 -v /var/www/gmi:/gmi -v /var/www/gmi/.certificates:/app/.certificates -e HOSTNAME=example.org -e LANG=en-US agate:latest
 ```
 
 You have to replace `/var/www/gmi/` with the folder where you'd like to have gemtext files and `/var/www/gmi/.certificates/` with the folder where you'd like to have your certificates stored. You also have to have to replace `example.org` with your domain name and if plan to speak in a different language than english in your gemini space than you should replace `en-US` with your countries language code (for example de-DE or fr-CA).


### PR DESCRIPTION
I updated the following things in the `docker run` instructions:
* fixed the path for the certificates inside the docker container, it had changed with cpnfeeny's latest commit
* remove trailing slashes for docker bind mounts for better legibility
* add `--name agate` to give the container a name