### PR TITLE
Allow proxy requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Agate also supports different certificates for different hostnames, see the sect
 
 If you want to serve the same content for multiple domains, you can instead disable the hostname check by not specifying `--hostname`. In this case Agate will disregard a request's hostname apart from checking that there is one.
 
+When one or more `--hostname`s are specified, Agate will check that the hostnames and port in request URLs match the specified hostnames and the listening ports. If Agate is behind a proxy on another port and receives a request wil an URL specifying the proxy port, this port may not match one of Agate's listening ports and the request will be rejected: it is possible to disable the port check with `--skip-port-check`.
+
 ### Certificates
 
 Agate has support for using multiple certificates with the `--certs` option. Agate will thus always require that a client uses SNI, which should not be a problem since the Gemini specification also requires SNI to be used.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -373,6 +373,25 @@ fn port_check() {
 }
 
 #[test]
+/// - port is not checked if the skip option is passed.
+fn port_check_skipped() {
+    let page = get(
+        &[
+            "--addr",
+            "[::]:19720",
+            "--hostname",
+            "example.org",
+            "--skip-port-check",
+        ],
+        addr(19720),
+        "gemini://example.org:1971/",
+    )
+    .expect("could not get page");
+
+    assert_eq!(page.header.status, Status::Success);
+}
+
+#[test]
 /// - status for paths with hidden segments is "gone" if file does not exist
 fn secret_nonexistent() {
     let page = get(


### PR DESCRIPTION
Hey! This PR lets Agate handle requests with an URL specifying a port different than the port it currently binds to. It adds an option to specify exactly which proxy port is accepted on which local port.