### PR TITLE
Update install instruction of Nix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ Download and unpack the [pre-compiled binary](https://github.com/mbrubeck/agate/
 
 Using the nix package manager run `nix-env -i agate`
 
-_Note:_ agate is currently only in the unstable channel and will reach a release channel once the next release is tagged
-
 ### Guix System
 
 [Deploy](https://dataswamp.org/~solene/2021-06-17-guix-gemini.html) agate with GNU Guix System by adding the [agate-service-type](https://guix.gnu.org/manual/en/html_node/Web-Services.html) to your system [services](http://guix.gnu.org/manual/en/html_node/Services.html). 


### PR DESCRIPTION
`agate` has already entered the stable channel of Nix/NixOS, so I removed the extra note in the README.