### PR TITLE
remove perms and ignore dependabot prs for cargo audit check

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -6,13 +6,14 @@ on:
       - "**/Cargo.lock"
   schedule:
     - cron: "0 14 * * *" # 14:00 UTC
-permissions:
-  repository-projects: read
 jobs:
   cargo-audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/audit-check@v1
+        # Don't run on dependabot PRs or forks
+        # https://github.com/actions-rs/clippy-check/issues/2#issuecomment-807852653
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The perms restriction is preventing it from posting the report result.
I've also restricted it so it wont run when on a dependabot or a fork to be safe.

