### PR TITLE
bump minimum required deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ getopts = "0.2.21"
 glob = "0.3"
 log = "0.4"
 mime_guess = "2.0"
-once_cell = "1.5"
+once_cell = "1.8"
 percent-encoding = "2.1"
 rcgen = { version = "0.8.14" }
 rustls = "0.20.0"
 tokio-rustls = "0.23.0"
-tokio = { version = "1.2", features = ["fs", "io-util", "net", "rt-multi-thread", "sync"] }
-url = "2.2.1"
+tokio = { version = "1.12", features = ["fs", "io-util", "net", "rt-multi-thread", "sync"] }
+url = "2.2.2"
 webpki = "0.22.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Just bumping the minimum required deps version to avoid `maybe insecure` label
https://deps.rs/repo/github/mbrubeck/agate

All of these versions are already being used in the cargo lock due to ^ semver
I guess deps.rs only goes off of the Cargo.toml incase it's used as a lib too?

