### PR TITLE
fix ports

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,8 @@ use {
     url::{Host, Url},
 };
 
+static DEFAULT_PORT: u16 = 1965;
+
 fn main() {
     env_logger::Builder::from_env(
         // by default only turn on logging for agate
@@ -136,7 +138,7 @@ fn args() -> Result<Args> {
     opts.optmulti(
         "",
         "addr",
-        "Address to listen on (default 0.0.0.0:1965 and [::]:1965; muliple occurences means listening on multiple interfaces)",
+        &format!("Address to listen on (default 0.0.0.0:{} and [::]:{}; muliple occurences means listening on multiple interfaces)", DEFAULT_PORT, DEFAULT_PORT),
         "IP:PORT",
     );
     opts.optmulti(
@@ -288,8 +290,8 @@ fn args() -> Result<Args> {
     }
     if addrs.is_empty() {
         addrs = vec![
-            SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 1965),
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 1965),
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), DEFAULT_PORT),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), DEFAULT_PORT),
         ];
     }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,5 +1,5 @@
 # Tests for the Agate gemini server
 
-This folder contains some tests and data used for these tests. Although care is taken to remove any interdependencies between these tests, these may happen. If you want to be on the safe side you could use `cargo test -- --test-threads=1` to run the tests sequentially.
+This folder contains some tests and data used for these tests.
 
 Also note that you should **NEVER USE THE CERTIFICATE AND KEY DATA PROVIDED HERE** since it is public.


### PR DESCRIPTION
Once again I'm updating agate for nixpkgs and there's a duplicate port in use!!!!
I am here to fix the problem for evermore :smiley: 

To find the duplicate port in the existing code if you're curious:

`rg "addr\(\d+\)" tests/tests.rs -o --no-line-number | sort | uniq -d`

`grep -E 'addr\(([0-9]+)\)' tests/tests.rs -o | sort | uniq -d`

I solved the port collisions by moving the port into the generator functions and using an atomic


changes:

- define default port in one place
- fix port collision once and for all
