### PR TITLE
Refactor Dockerfile for multi-stage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+**
+
+!src/**
+!tools/docker/**
+!Cross.toml
+!Cargo.toml
+!Cargo.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM docker.io/library/rust:alpine AS builder
 
 WORKDIR /agate
+RUN apk --no-cache add libc-dev
+
 COPY src src
 COPY Cargo.toml .
 COPY Cargo.lock .
 COPY Cross.toml .
-RUN apk --no-cache add libc-dev && \
-    cargo install --target x86_64-unknown-linux-musl --path .
+RUN cargo install --target x86_64-unknown-linux-musl --path .
 
 FROM docker.io/library/alpine:latest
 COPY --from=builder /usr/local/cargo/bin/agate /usr/bin/agate

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM docker.io/library/rust:alpine AS builder
+# RUN wget -O source.tar.gz $(wget -qO- https://api.github.com/repos/mbrubeck/agate/releases/latest | sed -nE 's/^.*"tarball_url"\s*:\s*"([^"]+)".*$/\1/p')&& tar xzf source.tar.gz && \
+#     mv mbrubeck-agate-* /agate
+
+WORKDIR /agate
+COPY src src
+COPY Cargo.toml .
+COPY Cargo.lock .
+COPY Cross.toml .
+RUN apk --no-cache add libc-dev && \
+    cargo install --target x86_64-unknown-linux-musl --path .
+
+FROM docker.io/library/alpine:latest
+COPY --from=builder /usr/local/cargo/bin/agate /usr/bin/agate
+WORKDIR /app
+COPY tools/docker/start.sh /app
+ENTRYPOINT ["/bin/sh", "start.sh"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
 FROM docker.io/library/rust:alpine AS builder
-# RUN wget -O source.tar.gz $(wget -qO- https://api.github.com/repos/mbrubeck/agate/releases/latest | sed -nE 's/^.*"tarball_url"\s*:\s*"([^"]+)".*$/\1/p')&& tar xzf source.tar.gz && \
-#     mv mbrubeck-agate-* /agate
 
 WORKDIR /agate
 COPY src src

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN apk --no-cache add libc-dev && \
 FROM docker.io/library/alpine:latest
 COPY --from=builder /usr/local/cargo/bin/agate /usr/bin/agate
 WORKDIR /app
-COPY tools/docker/start.sh /app
-ENTRYPOINT ["/bin/sh", "start.sh"]
+EXPOSE 1965
+VOLUME /gmi/
+VOLUME /certs/
+
+ENTRYPOINT ["agate", "--addr", "0.0.0.0:1965", "--content", "/gmi/", "--certs", "/certs/"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN apk --no-cache add libc-dev
 COPY src src
 COPY Cargo.toml .
 COPY Cargo.lock .
-COPY Cross.toml .
 RUN cargo install --target x86_64-unknown-linux-musl --path .
 
 FROM docker.io/library/alpine:latest

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,8 +1,0 @@
-FROM alpine:latest
-RUN apk add cargo && wget -O source.tar.gz $(wget -qO- https://api.github.com/repos/mbrubeck/agate/releases/latest | sed -nE 's/^.*"tarball_url"\s*:\s*"([^"]+)".*$/\1/p')&& tar xzf source.tar.gz && mv /mbrubeck-agate-* /agate && cd agate && cargo build --release
-RUN cp /agate/target/release/agate /usr/bin/agate
-WORKDIR /app
-COPY . /app
-ADD . .
-ENTRYPOINT ["/bin/sh", "start.sh"]
-

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -30,12 +30,8 @@ cd agate
 ```
 
 ## build the image
-Enter the `tools/docker` directory:
 
-```
-cd tools/docker
-```
-And now build the docker image:
+Now build the docker image:
 
 ```
 docker build -t agate .
@@ -45,7 +41,7 @@ This process will take a few minutes because all the rust modules have to be com
 ## start the docker container
 
 ```
-docker run -t -d --name agate -p 1965:1965 -v /var/www/gmi:/gmi -v /var/www/gmi/.certificates:/app/.certificates -e HOSTNAME=example.org -e LANG=en-US agate:latest
+docker run -t -d --name agate -p 1965:1965 -v path/to/gmi:/gmi:ro -v path/to/certs:/certs:rw agate:latest --hostname localhost
 ```
 
 You have to replace `/var/www/gmi/` with the folder where you'd like to have gemtext files and `/var/www/gmi/.certificates/` with the folder where you'd like to have your certificates stored. You also have to have to replace `example.org` with your domain name and if plan to speak in a different language than english in your gemini space than you should replace `en-US` with your countries language code (for example de-DE or fr-CA).

--- a/tools/docker/start.sh
+++ b/tools/docker/start.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-exec agate --content /gmi/ \
-	--hostname ${HOSTNAME} \
-	--lang ${LANG}
+echo "Using hostname ${HOSTNAME:-localhost}"
+echo "Using lang ${LANG:-en-US}"
 
+exec agate --content /gmi/ \
+	--hostname "${HOSTNAME:-localhost}" \
+	--lang "${LANG:-en-US}"

--- a/tools/docker/start.sh
+++ b/tools/docker/start.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-echo "Using hostname ${HOSTNAME:-localhost}"
-echo "Using lang ${LANG:-en-US}"
-
-exec agate --content /gmi/ \
-	--hostname "${HOSTNAME:-localhost}" \
-	--lang "${LANG:-en-US}"


### PR DESCRIPTION
I noticed that when building the Dockerfile, the resultant image had a size of 1.15GB! This did not pass the smell test for a small static Rust binary with an alpine base container.

The current Dockerfile uses a single-stage build, which means that the entire package cache, cargo cache, build cache, etc. are saved in a Docker image layer. This results in an absolutely enormous image.

This PR refactors the Dockerfile to use a multi-stage build, which first uses the `rust:alpine` Docker image to build the project. The second stage starts from a base alpine container, and only copies the statically compiled binary and the `start.sh` entrypoint script, which reduces size from 1.15GB to 11.4MB.

I quickly tested this out by using the new Docker image to serve a page, which I could access using `amfora`. I am not entirely familiar with all the bells and whistles of this project, so I recommend the primary maintainers further test the new Dockerfile before merging.

## Passing thoughts

### Use of `alpine` as final base instead of `scratch`

Just some additional thoughts regarding the Dockerfile -- the only reason I used `alpine:latest` as the final build stage instead of `scratch` is due to the `start.sh` script, which requires a shell to interpret it. However, the start script itself is very simple, being only one command. This command could easily be inlined directly in `Dockerfile`. The only problem is that [`CMD` command doesn't understand ENV variables](https://github.com/moby/moby/issues/5509). In addition, as `scratch` does not contain a shell, shell expansion of the environment variable won't work regardless.

If `agate` itself can be refactored to be configured by environment variables in addition to traditional command line flags, we can use the `ENV` directive in the Dockerfile to configure the runtime arguments of `agate`, and skip the startup script entirely. This will allow us to use `scratch` as the base container, which would save ~5.9MB -- the size of the `alpine` base container (non-insignificant compared to currently proposed final size of 11.4MB).

This can be addressed in a future PR if there is sufficient interest, and I am glad to implement that as well. I just want to make sure it is actually a desired feature before spending time to implement it -- don't want to spend time writing it just to be shot down due to differing design philosophies.