### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/.certificates


### PR DESCRIPTION
The .certificates directory is generated when running the program.
However, it is not made to be published.
Adding it to the .gitignore file avoids accidentally adding it.