### PR TITLE
Fix hostname in ExecStart command

### DIFF
--- a/tools/debian/gemini.service
+++ b/tools/debian/gemini.service
@@ -13,7 +13,7 @@ Description=Agate gemini server
 # and place the contents to be displayed in /srv/gemini/content
 WorkingDirectory=/srv/gemini/
 # assumes the device hostname is set correctly
-ExecStart=agate --hostname $(uname -n) --lang en
+ExecStart=/bin/sh -c "agate --hostname $(uname -n) --lang en"
 
 Restart=always
 RestartSec=1


### PR DESCRIPTION
systemd apparently doesn't interpret ExecStart options using full shell syntax, so `agate --hostname $(uname -n) --lang en` gets mangled to `agate --hostname "-n)" --lang en` since systemd expands `$(uname` as an environmental variable.

This commit invokes `/bin/sh` with the shell command in quotes (as is the style, I think?) From https://freedesktop.org/software/systemd/man/systemd.service.html#Command%20lines:
>Note that shell command lines are not directly supported. If shell command lines are to be used, they need to be passed explicitly to a shell implementation of some kind. Example:
>`ExecStart=sh -c 'dmesg | tac'`