### PR TITLE
Added aarch64 support to Docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,10 +103,17 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,15 @@ RUN apk --no-cache add libc-dev
 COPY src src
 COPY Cargo.toml .
 COPY Cargo.lock .
-RUN cargo install --target x86_64-unknown-linux-musl --path .
+ARG TARGETARCH
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+      cargo install --target x86_64-unknown-linux-musl --path . ; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+      cargo install --target aarch64-unknown-linux-musl --path . ; \
+    else \
+      echo "The architecture $TARGETARCH isn't unsupported." && exit 1; \
+    fi
 
 FROM docker.io/library/alpine:latest
 COPY --from=builder /usr/local/cargo/bin/agate /usr/bin/agate

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ COPY src src
 COPY Cargo.toml .
 COPY Cargo.lock .
 ARG TARGETARCH
-ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
       cargo install --target x86_64-unknown-linux-musl --path . ; \
     elif [ "$TARGETARCH" = "arm64" ]; then \


### PR DESCRIPTION
Howdy! Please bear with me—this is my first non-documentation PR. I was able to get a Docker image that works on my ARM device by

- Adding both `linux/amd64` and `linux/arm64` as target platforms in the Github workflow, and
- Replacing hardcoded architectures in the Dockerfile with these targets.

This resolves #375.

If there's any documentation I need to provide, please let me know!